### PR TITLE
Add Scratch Usage Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Nick: Ignore emacs save files
+\#*\#
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
- Add additional check for Scratch usage
- Skip this check if SSH is down

Example output:
```bash
n0124.savio2 drain  2018-10-18T16:57:39 root      no ib                                                                  ## ssh:  up scratch:  NotFound
n0068.savio2 drain  2018-07-16T11:52:41 root      see hung mpirun for jhlee84--Tin                                       ## ssh:  up scratch:      1.4P
n0113.savio2 down*  2018-06-26T10:44:57 root      HW:shutdownAgainWontPowerOn_openCase                                   ## ssh:DOWN scratch: (skipped)
n0107.savio2 down*  2018-06-26T10:08:33 root      HW.ReseatedManyTime_WontPowerOn.Tin                                    ## ssh:DOWN scratch: (skipped)
```